### PR TITLE
Fix upside down inductors and enhance arc-ellipse conversion.

### DIFF
--- a/rust-hdl-pcb/src/inductors.rs
+++ b/rust-hdl-pcb/src/inductors.rs
@@ -35,7 +35,7 @@ pub fn make_ty_brl_series(part_number: &str) -> CircuitNode {
     outline.extend(
         (0..=3)
             .into_iter()
-            .map(|x| make_arc(-150 + x * 100, 0, 50.0, 179.9, -179.9))
+            .map(|x| make_arc(-150 + x * 100, 0, 50.0, -179.9, 179.9))
             .collect::<Vec<_>>(),
     );
     let line1: String = label.split(" ").take(2).collect::<Vec<_>>().join(" ");

--- a/rust-hdl-pcb/src/schematic.rs
+++ b/rust-hdl-pcb/src/schematic.rs
@@ -4,7 +4,7 @@ use crate::circuit::{
     SchematicRotation,
 };
 use crate::epin::{EPin, EdgeLocation};
-use crate::glyph::{estimate_bounding_box, Glyph, Rect, TextJustification};
+use crate::glyph::{estimate_bounding_box, Glyph, Rect, TextJustification, Point};
 use svg::node::element::path::Data;
 use svg::node::element::{Text, Circle};
 use svg::node::element::{Group, Path};
@@ -191,6 +191,20 @@ fn add_pins(
     doc
 }
 
+// Adapted from https://stackoverflow.com/questions/21816286/svg-arc-how-to-determine-sweep-and-larg-arc-flags-given-start-end-via-point
+fn angle (a: (f64,f64), b: (f64,f64), c: (f64,f64)) -> f64 {
+    let pi = std::f64::consts::PI;
+    ( f64::atan2(( c.1 - b.1 ) ,( c.0 - b.0 ) )
+        - f64::atan2(( a.1 - b.1 ) ,( a.0 - b.0 ) )
+        + 3.0 * pi )
+        %( 2.0 * pi ) - pi
+}
+
+fn find_sweep_flag (start: (f64,f64), via: (f64,f64), end: (f64,f64)) -> i32 {
+    return if angle(end, start, via) > 0.0 { 0 } else { 1 };
+}
+
+
 pub fn add_outline_to_path(doc: Group, g: &Glyph, hide_outline: bool) -> Group {
     match g {
         Glyph::OutlineRect(r) => {
@@ -250,13 +264,18 @@ pub fn add_outline_to_path(doc: Group, g: &Glyph, hide_outline: bool) -> Group {
             let p1x = a.p0.x as f64 + a.radius * f64::cos(a.start_angle.to_radians());
             let p1y = a.p0.y as f64 + a.radius * f64::sin(a.start_angle.to_radians());
             let p2x = a.p0.x as f64
-                + a.radius * f64::cos(a.start_angle.to_radians() + a.sweep_angle.to_radians());
+                + a.radius * f64::cos(a.start_angle.to_radians() + a.sweep_angle.to_radians() / 2.0);
             let p2y = a.p0.y as f64
+                + a.radius * f64::sin(a.start_angle.to_radians() + a.sweep_angle.to_radians() / 2.0);
+            let p3x = a.p0.x as f64
+                + a.radius * f64::cos(a.start_angle.to_radians() + a.sweep_angle.to_radians());
+            let p3y = a.p0.y as f64
                 + a.radius * f64::sin(a.start_angle.to_radians() + a.sweep_angle.to_radians());
-            let sweep_flag = if a.sweep_angle < 0.0 { 0 } else { 1 };
+            let sweep_flag = find_sweep_flag((p1x, p1y), (p2x, p2y), (p3x , p3y));
+            let large_arc_flag = if f64::abs(a.sweep_angle) > 180.0 { 1 } else { 0 };
             let data = Data::new()
                 .move_to((p1x, p1y))
-                .elliptical_arc_to((a.radius, a.radius, 0.0, 0, sweep_flag, p2x, p2y));
+                .elliptical_arc_to((a.radius, a.radius, 0.0, large_arc_flag, sweep_flag, p3x, p3y));
             doc.add(
                 Path::new()
                     .set("fill", "none")
@@ -264,6 +283,30 @@ pub fn add_outline_to_path(doc: Group, g: &Glyph, hide_outline: bool) -> Group {
                     .set("stroke-width", 10)
                     .set("d", data),
             )
+                /*
+                //useful for debugging arcs/ellipses
+                .add(Circle::new()
+                .set("cx", p1x)
+                .set("cy", p1y)
+                .set("r", 10)
+                .set("fill", "#00FF00")
+                .set("stroke", "#00FF00")
+                .set("stroke-width", 10))
+                .add(Circle::new()
+                    .set("cx", p2x)
+                    .set("cy", p2y)
+                    .set("r", 10)
+                    .set("fill", "#FF3399")
+                    .set("stroke", "#FF3399")
+                    .set("stroke-width", 10))
+                .add(Circle::new()
+                    .set("cx", p3x)
+                    .set("cy", p3y)
+                    .set("r", 10)
+                    .set("fill", "#FF3300")
+                    .set("stroke", "#FF3300")
+                    .set("stroke-width", 10))
+*/
         },
         Glyph::Circle(a) => {
             doc.add(

--- a/rust-hdl-pcb/src/schematic.rs
+++ b/rust-hdl-pcb/src/schematic.rs
@@ -4,14 +4,13 @@ use crate::circuit::{
     SchematicRotation,
 };
 use crate::epin::{EPin, EdgeLocation};
-use crate::glyph::{estimate_bounding_box, Glyph, Rect, TextJustification, Point};
+use crate::glyph::{estimate_bounding_box, Glyph, Rect, TextJustification};
 use svg::node::element::path::Data;
 use svg::node::element::{Text, Circle};
 use svg::node::element::{Group, Path};
 use svg::Document;
 use std::collections::BTreeMap;
 use std::fs;
-use std::path;
 
 const EM: i32 = 85;
 const PIN_LENGTH: i32 = 200;
@@ -194,8 +193,8 @@ fn add_pins(
 // Adapted from https://stackoverflow.com/questions/21816286/svg-arc-how-to-determine-sweep-and-larg-arc-flags-given-start-end-via-point
 fn angle (a: (f64,f64), b: (f64,f64), c: (f64,f64)) -> f64 {
     let pi = std::f64::consts::PI;
-    ( f64::atan2(( c.1 - b.1 ) ,( c.0 - b.0 ) )
-        - f64::atan2(( a.1 - b.1 ) ,( a.0 - b.0 ) )
+    ( f64::atan2( c.1 - b.1 , c.0 - b.0 )
+        - f64::atan2( a.1 - b.1 ,a.0 - b.0 )
         + 3.0 * pi )
         %( 2.0 * pi ) - pi
 }
@@ -548,7 +547,7 @@ pub fn make_svgs(mut part: &mut PartInstance) {
     let base_path = std::path::Path::new( &base);
     let base_dir = base_path.parent().unwrap();
     if !base_dir.exists() {
-        fs::create_dir_all(base_dir);
+        fs::create_dir_all(base_dir).expect("failed to create symbols directory");
     }
     write_to_svg(&part, &format!("{}.svg", base));
     part.schematic_orientation.flipped_lr = true;


### PR DESCRIPTION
Inductors were being drawn upside down by inductors.rs.

The logic for determining sweep_flag for ellipse paths was not correct in 100% of cases. Replaced the existing flag with better logic using the angle between start, end, and via point to determine sweep_flag. Also added logic to support arcs larger than 180 degrees.